### PR TITLE
Don't allow connections to IPv6 addresses

### DIFF
--- a/Matrix.SynapseInterop.Replication/SynapseReplication.cs
+++ b/Matrix.SynapseInterop.Replication/SynapseReplication.cs
@@ -42,9 +42,9 @@ namespace Matrix.SynapseInterop.Replication
                 // TcpClient doesn't support IPV6 :(
                 ip = dns.AddressList.First(i => i.AddressFamily == AddressFamily.InterNetwork);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex)
             {
-                throw new Exception($"ERROR: No IPv4 address found for {address}");
+                throw new InvalidOperationException($"No IPv4 address found for {address}", ex);
             }
             
             // Form a connection

--- a/Matrix.SynapseInterop.Replication/SynapseReplication.cs
+++ b/Matrix.SynapseInterop.Replication/SynapseReplication.cs
@@ -36,8 +36,17 @@ namespace Matrix.SynapseInterop.Replication
 
             // Resolve the address
             var dns = await Dns.GetHostEntryAsync(address);
-            var ip = dns.AddressList[0];
-
+            IPAddress ip;
+            try
+            {
+                // TcpClient doesn't support IPV6 :(
+                ip = dns.AddressList.First(i => i.AddressFamily == AddressFamily.InterNetwork);
+            }
+            catch (InvalidOperationException)
+            {
+                throw new Exception($"ERROR: No IPv4 address found for {address}");
+            }
+            
             // Form a connection
             _client = new TcpClient();
             await _client.ConnectAsync(ip, port);


### PR DESCRIPTION
TcpClient doesn't support it, and is made of fail. https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.-ctor?view=netframework-4.7#System_Net_Sockets_TcpClient__ctor