### PR TITLE
Support creating receipts on the federation sender

### DIFF
--- a/Matrix.SynapseInterop.Replication/DataRows/ReceiptStreamRow.cs
+++ b/Matrix.SynapseInterop.Replication/DataRows/ReceiptStreamRow.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Matrix.SynapseInterop.Replication.DataRows
+{
+    public class ReceiptStreamRow : IReplicationDataRow
+    {
+        public string EventId { get; private set; }
+        public string RoomId { get; private set; }
+        public string UserId { get; private set; }
+        public JObject Data { get; private set; }
+        public string RecieptType { get; private set; }
+        private ReceiptStreamRow() { }
+
+        public static ReceiptStreamRow FromRaw(string rawDataString)
+        {
+            var parsed = JsonConvert.DeserializeObject<List<dynamic>>(rawDataString);
+
+            return new ReceiptStreamRow
+            {
+                RoomId = parsed[0],
+                RecieptType = parsed[1],
+                UserId = parsed[2],
+                EventId = parsed[3],
+                Data = JObject.Parse(parsed[4]),
+            };
+        }
+    }
+}

--- a/Matrix.SynapseInterop.Replication/ReplicationStream.cs
+++ b/Matrix.SynapseInterop.Replication/ReplicationStream.cs
@@ -29,14 +29,16 @@ namespace Matrix.SynapseInterop.Replication
         private static readonly Dictionary<Type, string> DATA_ROW_STREAM_NAMES = new Dictionary<Type, string>
         {
             {typeof(EventStreamRow), ReplicationStreamName.EVENTS},
-            {typeof(FederationStreamRow), ReplicationStreamName.FEDERATION_OUTBOUND_QUEUE}
+            {typeof(FederationStreamRow), ReplicationStreamName.FEDERATION_OUTBOUND_QUEUE},
+            {typeof(ReceiptStreamRow), ReplicationStreamName.RECEIPTS},
         };
 
         private static readonly Dictionary<string, Func<string, IReplicationDataRow>> DATA_ROW_FACTORIES =
             new Dictionary<string, Func<string, IReplicationDataRow>>
             {
                 {ReplicationStreamName.EVENTS, raw => EventStreamRow.FromRaw(raw)},
-                {ReplicationStreamName.FEDERATION_OUTBOUND_QUEUE, raw => FederationStreamRow.FromRaw(raw)}
+                {ReplicationStreamName.FEDERATION_OUTBOUND_QUEUE, raw => FederationStreamRow.FromRaw(raw)},
+                {ReplicationStreamName.RECEIPTS, raw => ReceiptStreamRow.FromRaw(raw)},
             };
 
         private readonly SynapseReplication _replicationHost;

--- a/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
+++ b/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
@@ -17,6 +17,7 @@ namespace Matrix.SynapseInterop.Worker.FederationSender
         private readonly IConfiguration _config;
         private ReplicationStream<EventStreamRow> _eventStream;
         private ReplicationStream<FederationStreamRow> _fedStream;
+        private ReplicationStream<ReceiptStreamRow> _receiptStream;
         private int _last_ack;
         private bool _presenceEnabled;
         private int _stream_position;
@@ -49,8 +50,20 @@ namespace Matrix.SynapseInterop.Worker.FederationSender
             _fedStream = _synapseReplication.BindStream<FederationStreamRow>();
             _fedStream.DataRow += OnFederationRow;
             _eventStream = _synapseReplication.BindStream<EventStreamRow>();
-            _eventStream.PositionUpdate /**/ += OnEventPositionUpdate;
+            _eventStream.PositionUpdate += OnEventPositionUpdate;
             _stream_position = await GetFederationPos("federation");
+            
+            // Newer versions of synapse expect us to create reciepts too.
+            if (_config.GetSection("federation").GetValue<bool>("handleReceipts"))
+            {
+                _receiptStream = _synapseReplication.BindStream<ReceiptStreamRow>();
+                _receiptStream.DataRow += OnReceiptRow;
+            }
+        }
+
+        private void OnReceiptRow(object sender, ReceiptStreamRow e)
+        {
+            _transactionQueue?.OnReciept(e);
         }
 
         private async Task<int> GetFederationPos(string type)

--- a/Matrix.SynapseInterop.Worker.FederationSender/RoomReceipt.cs
+++ b/Matrix.SynapseInterop.Worker.FederationSender/RoomReceipt.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+namespace Matrix.SynapseInterop.Worker.FederationSender
+{
+    public struct RoomReceipt
+    {
+        [JsonProperty("m.read")]
+        public UserReadReceipt MRead;
+    }
+
+    public struct UserReadReceipt
+    {
+        public string[] event_ids;
+        public RoomReceiptMetadata data;
+    }
+
+    public struct RoomReceiptMetadata
+    {
+        public int ts;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/turt2live/synapse-netcore-workers/issues/43

This is currently disabled behind a feature flag until synapse hits a release or something