### PR TITLE
Handle Replication Connection Loss

### DIFF
--- a/Matrix.SynapseInterop.Replication/SynapseReplication.cs
+++ b/Matrix.SynapseInterop.Replication/SynapseReplication.cs
@@ -84,7 +84,17 @@ namespace Matrix.SynapseInterop.Replication
             SendRaw("NAME " + name);
 
             // Start pinging 
-            _pingTimer = new Timer(SendPing, null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5));
+            _pingTimer = new Timer(context =>
+            {
+                try
+                {
+                    SendPing(context);
+                }
+                catch (Exception ex)
+                {
+                    log.Error("Ping failed: {ex}", ex);
+                }
+            }, null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5));
 
             // Start the reader
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
@@ -94,7 +104,6 @@ namespace Matrix.SynapseInterop.Replication
             Connected?.Invoke(this, null);
         }
 
-        private async Task ReconnectLoop()
         private async void ReconnectLoop()
         {
             if (ReconnectionInProgress)

--- a/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
+++ b/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
@@ -134,7 +134,18 @@ namespace Matrix.SynapseInterop.Worker.FederationSender
 
             if (_last_ack >= _stream_position) return;
 
-            _synapseReplication.SendFederationAck(_stream_position.ToString());
+            try
+            {
+                _synapseReplication.SendFederationAck(_stream_position.ToString());
+            }
+            catch (Exception ex)
+            {
+                // TODO: Is this correct? We update the token in the DB so
+                // a restarted master should be okay, but it might also mean that
+                // we might see duplicate traffic on connection loss.
+                log.Error("Failed to ACK federation, dropping. {ex}", ex);
+            }
+            
             _last_ack = token;
             saveFedToken.Stop();
             saveFedToken.Start();


### PR DESCRIPTION
This aims to fix #40 and #41.

This works by:
- Allowing only allowing one ReconnectLoop to run.
- Not throwing inside the Timer if SendPing fails, but just log the error.
- Catching a failure to ack federation traffic.