### PR TITLE
Make maxHostsForPresence configurable

### DIFF
--- a/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
+++ b/Matrix.SynapseInterop.Worker.FederationSender/FederationSender.cs
@@ -141,7 +141,8 @@ namespace Matrix.SynapseInterop.Worker.FederationSender
             _transactionQueue = new TransactionQueue(serverName,
                                                      connectionString,
                                                      key,
-                                                     _config.GetSection("Federation"));
+                                                     _config.GetSection("Federation"),
+                                                     _config.GetSection("Caches"));
         }
 
         private void UpdateToken(int token)

--- a/Matrix.SynapseInterop.Worker.FederationSender/TransactionQueue.cs
+++ b/Matrix.SynapseInterop.Worker.FederationSender/TransactionQueue.cs
@@ -22,8 +22,8 @@ namespace Matrix.SynapseInterop.Worker.FederationSender
     {
         private const int MAX_PDUS_PER_TRANSACTION = 50;
         private const int MAX_EDUS_PER_TRANSACTION = 100;
-        // If a room has more hosts than MAX_HOSTS_FOR_PRESENCE, ignore that room.
-        private readonly int _maxHostsForPresence = 40;
+        // If a room has more hosts than _maxHostsForPresence, ignore that room.
+        private readonly int _maxHostsForPresence;
         private readonly TimeSpan minDelayBetweenTxns = TimeSpan.FromMilliseconds(150);
         private static readonly ILogger log = Log.ForContext<TransactionQueue>();
         private readonly Backoff _backoff;

--- a/Matrix.SynapseInterop.Worker.FederationSender/appsettings.default.json
+++ b/Matrix.SynapseInterop.Worker.FederationSender/appsettings.default.json
@@ -13,7 +13,8 @@
     },
     "Federation": {
         "allowSelfSigned": true,
-        "defaultToSecurePort": true
+        "defaultToSecurePort": true,
+        "maxHostsForPresence": -1
     },
     "Logging": {
         "level": "info",


### PR DESCRIPTION
Previously this was set to 40 to prevent lots of EDUs to hosts that we presume not to care about. Obviously this should be configurable for users who may want to tune it up or down,

This is a somewhat breaking change, but the default is -1 to be in keeping with Synapse's own logic.